### PR TITLE
Support GFAL XXXdir operations, check errors from getRadosStriper

### DIFF
--- a/src/XrdCeph/XrdCephOss.cc
+++ b/src/XrdCeph/XrdCephOss.cc
@@ -168,12 +168,14 @@ int XrdCephOss::Create(const char *tident, const char *path, mode_t access_mode,
 
 int XrdCephOss::Init(XrdSysLogger *logger, const char* configFn) { return 0; }
 
+//SCS - lie to posix-assuming clients about directories [fixes brittleness in GFAL2]
 int XrdCephOss::Mkdir(const char *path, mode_t mode, int mkpath, XrdOucEnv *envP) {
-  return -ENOTSUP;
+  return 0;
 }
 
+//SCS - lie to posix-assuming clients about directories [fixes brittleness in GFAL2]
 int XrdCephOss::Remdir(const char *path, int Opts, XrdOucEnv *eP) {
-  return -ENOTSUP;
+  return 0;
 }
 
 int XrdCephOss::Rename(const char *from,

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -653,7 +653,15 @@ int ceph_posix_open(XrdOucEnv* env, const char *pathname, int flags, mode_t mode
 
   struct stat buf;
   libradosstriper::RadosStriper *striper = getRadosStriper(fr); //Get a handle to the RADOS striper API
+ 
+  if (NULL == striper) {
+    logwrapper((char*)"Cannot create striper");  
+    return -EINVAL;
+  }
+ 
   int rc = striper->stat(fr.name, (uint64_t*)&(buf.st_size), &(buf.st_atime)); //Get details about a file
+  
+ 
   bool fileExists = (rc != -ENOENT); //Make clear what condition we are testing
 
   if ((flags&O_ACCMODE) == O_RDONLY) {  // Access mode is READ


### PR DESCRIPTION
Provide better interoperability with GFAL applications such as FTS by pretending in XrdOssCeph.cc that mkdir and remdir are supported. 
Check in XrdCephPosix/ceph_posix_open that the return value from getRadosStriper is checked (see https://github.com/xrootd/xrootd-ceph/commit/9e856d490c805928b3ace33150ea2256a5e00f82#r44145472)
