### PR TITLE
Library dep uses target name

### DIFF
--- a/cmake/FindXRootD.cmake
+++ b/cmake/FindXRootD.cmake
@@ -7,7 +7,7 @@
 
 if( XRDCEPH_SUBMODULE )
   set( XROOTD_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src )
-  set( XROOTD_LIBRARIES    ${CMAKE_BINARY_DIR}/src/libXrdUtils.so )
+  set( XROOTD_LIBRARIES    XrdUtils )
 else()
   find_path( XROOTD_INCLUDE_DIRS XrdSfs/XrdSfsAio.hh
     HINTS


### PR DESCRIPTION
When building as a submodule, dependencies on libraries in the main package should use target names rather than paths.

If paths are used, cmake does not handle dependencies between targets and may attempt to build them in the wrong order:

gmake[2]: *** No rule to make target 'src/libXrdUtils.so', needed by 'src/XrdCeph/src/libXrdCephPosix.so.0.0.1'.  Stop.
