### PR TITLE
Fixing spelling errors

### DIFF
--- a/docs/ReleaseNotes.txt
+++ b/docs/ReleaseNotes.txt
@@ -309,7 +309,7 @@ Version 4.4.0
 + **Major bug fixes**
   * **[Posix]** Remove double unlock of a mutex.
   * **[Client]** Serialize security protocol manager to allow MT loads.
-  * **[Authentication/sss]** Fix dynamic id incompatability introduced in 4.0.
+  * **[Authentication/sss]** Fix dynamic id incompatibility introduced in 4.0.
   * **[XtdHttp]** Removed the deprecated cipher SSLv3, in favor of TLS1.2
   * **[XrdCl]** Close file on open timeout.
   * **[XrdCl]** Differentiate between a handshake and an xrootd request/response 
@@ -474,7 +474,7 @@ Version 4.2.2
   * **[XrdCl]** xrdfs correctly handles quotations (fixes the problem with ALICE token)
 
 + **Miscellaneous**
-  * Fixes #245 Provide compatability when cmake version is > 3.0.
+  * Fixes #245 Provide compatibility when cmake version is > 3.0.
   * Use atomics to manipulate unlocked variable pollNum.
   * Bugfix: release lock when a file is closed before the prefetch thread is started. 
     Observed with xrdcp ran without -f option and an existing local file. Fixes #239.
@@ -496,7 +496,7 @@ Version 4.2.1
 
 + **Miscellaneous**
    * **[Client/Cl]** Make sure kXR_mkpath is set for classic copy jobs when the
-     destination is xrootd (backward compatability fix).
+     destination is xrootd (backward compatibility fix).
 
 -------------
 Version 4.2.0
@@ -964,7 +964,7 @@ Version 3.3.2
 + **Major bug fixes**
    * Fix the opaque information setting in xrdcp using -OD (issue #1)
    * Fix compilation on Solaris 11 (issue #7)
-   * Fix issues with semaphore locking during thread cancelation on
+   * Fix issues with semaphore locking during thread cancellation on
      MaxOSX (issue #10)
    * Solve locking problems in the built-in poller (issue #4)
    * Solve performance issues in the new client. Note: this actually
@@ -1218,7 +1218,7 @@ Version 3.2.0
      path (as opposed to a control path) in the monitoring record.
 
 + **Major bug fixes**
-   * Provide compatability for sprintf() implementations that check output
+   * Provide compatibility for sprintf() implementations that check output
      buffer length. This currently only affects gentoo and Ubuntu Linux.
      We place it in the "major" section as it causes run-time errors there.
    * Reinsert buffer size calculation that was mistakenly deleted.
@@ -1271,7 +1271,7 @@ Version 3.1.1
 
 + **Major bug fixes**
    * Fix various client threading issues.
-   * [bug #87880] Properly unpack the incomming vector read data.
+   * [bug #87880] Properly unpack the incoming vector read data.
    * Rework the handshake when making a parallel connection. Previous method
      caused a deadlock when parallel connections were requested (e.g. xrdcp).
    * Add HAVE_SENDFILE definition to cmake config. All post-cmake version of
@@ -1371,7 +1371,7 @@ Version 3.1.0
      meta-manager the minimum number of responses needed to satisfy a hold
      delay (i.e. fast redirect).
    * Accept XrdSecSSSKT envar as documented but also continue to support
-     XrdSecsssKT for backward compatability.
+     XrdSecsssKT for backward compatibility.
    * Allow servers to specify to the meta-manager what share of requests they
      are willing to handle. Add the 'cms.sched gsdflt' and 'cms.sched gshr'
      configuration directives to specify this.
@@ -1389,7 +1389,7 @@ Version 3.1.0
    * Finally implement adding authentication information to the user monitoring
      record (requested by Matevz Tadel, CMS). This adds a new generic option,
      auth, to the xrootd.monitor directive. It needs to be specified for the
-     authentication information to be added. This keeps backward compatability.
+     authentication information to be added. This keeps backward compatibility.
    * Add a new method, chksum, to the standard filesystem interface.
    * Integrate checksums into the logical filesystem layer implementation.
      See the ofs.ckslib directive on how to do non-default configuration.

--- a/src/XrdCeph/XrdCephOss.cc
+++ b/src/XrdCeph/XrdCephOss.cc
@@ -146,7 +146,7 @@ int XrdCephOss::Configure(const char *configfn, XrdSysError &Eroute) {
        }
      }
 
-     // Now check if any errors occured during file i/o
+     // Now check if any errors occurred during file i/o
      int retc = Config.LastError();
      if (retc) {
        NoGo = Eroute.Emsg("Config", -retc, "read config file",


### PR DESCRIPTION
Mostly found by lintian (Debian packaging debugging tool).
Reported as "spelling-error-in-binary" and "typo-in-manual-page"

I used grep to find the occurrences of the typos, so if the same typo appears in a comment or a text file and does not end up in a binary or man page, that was fixed to.
