### PR TITLE
Fix compilation failure on 32 bit architectures

### DIFF
--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -800,7 +800,7 @@ ssize_t ceph_posix_pwrite(int fd, const void *buf, size_t count, off64_t offset)
     XrdSysMutexHelper lock(fr->statsMutex);
     fr->wrcount++;
     fr->bytesWritten+=count;
-    if (offset + count) fr->maxOffsetWritten = std::max(offset + count - 1, fr->maxOffsetWritten);
+    if (offset + count) fr->maxOffsetWritten = std::max(uint64_t(offset + count - 1), fr->maxOffsetWritten);
     return count;
   } else {
     return -EBADF;
@@ -819,7 +819,7 @@ static void ceph_aio_write_complete(rados_completion_t c, void *arg) {
     fr->bytesAsyncWritePending -= awa->nbBytes;
     fr->bytesWritten += awa->nbBytes;
     if (awa->aiop->sfsAio.aio_nbytes)
-      fr->maxOffsetWritten = std::max(fr->maxOffsetWritten, awa->aiop->sfsAio.aio_offset + awa->aiop->sfsAio.aio_nbytes - 1);
+      fr->maxOffsetWritten = std::max(fr->maxOffsetWritten, uint64_t(awa->aiop->sfsAio.aio_offset + awa->aiop->sfsAio.aio_nbytes - 1));
     ::timeval now;
     ::gettimeofday(&now, nullptr);
     double writeTime = 0.000001 * (now.tv_usec - awa->startTime.tv_usec) + 1.0 * (now.tv_sec - awa->startTime.tv_sec);


### PR DESCRIPTION
armel, armhf, i386, mipsel, m68k, sh4, x32
```
.../xrootd-5.3.1/src/XrdCeph/src/XrdCeph/XrdCephPosix.cc: In function 'ssize_t ceph_posix_pwrite(int, const void*, size_t, off64_t)':
.../xrootd-5.3.1/src/XrdCeph/src/XrdCeph/XrdCephPosix.cc:803:97: error: no matching function for call to 'max(off64_t, uint64_t&)'
  803 |     if (offset + count) fr->maxOffsetWritten = std::max(offset + count - 1, fr->maxOffsetWritten);
      |                                                                                                 ^
In file included from /usr/include/c++/10/memory:63,
                 from .../xrootd-5.3.1/src/XrdCeph/src/XrdCeph/XrdCephPosix.cc:36:
/usr/include/c++/10/bits/stl_algobase.h:254:5: note: candidate: 'template<class _Tp> constexpr const _Tp& std::max(const _Tp&, const _Tp&)'
  254 |     max(const _Tp& __a, const _Tp& __b)
      |     ^~~
/usr/include/c++/10/bits/stl_algobase.h:254:5: note:   template argument deduction/substitution failed:
.../xrootd-5.3.1/src/XrdCeph/src/XrdCeph/XrdCephPosix.cc:803:97: note:   deduced conflicting types for parameter 'const _Tp' ('long long int' and 'uint64_t' {aka 'long long unsigned int'})
  803 |     if (offset + count) fr->maxOffsetWritten = std::max(offset + count - 1, fr->maxOffsetWritten);
      |                                                                                                 ^
In file included from /usr/include/c++/10/memory:63,
                 from .../xrootd-5.3.1/src/XrdCeph/src/XrdCeph/XrdCephPosix.cc:36:
/usr/include/c++/10/bits/stl_algobase.h:300:5: note: candidate: 'template<class _Tp, class _Compare> constexpr const _Tp& std::max(const _Tp&, const _Tp&, _Compare)'
  300 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^~~
/usr/include/c++/10/bits/stl_algobase.h:300:5: note:   template argument deduction/substitution failed:
.../xrootd-5.3.1/src/XrdCeph/src/XrdCeph/XrdCephPosix.cc:803:97: note:   deduced conflicting types for parameter 'const _Tp' ('long long int' and 'uint64_t' {aka 'long long unsigned int'})
  803 |     if (offset + count) fr->maxOffsetWritten = std::max(offset + count - 1, fr->maxOffsetWritten);
      |                                                                                                 ^
.../xrootd-5.3.1/src/XrdCeph/src/XrdCeph/XrdCephPosix.cc: In function 'void ceph_aio_write_complete(rados_completion_t, void*)':
.../xrootd-5.3.1/src/XrdCeph/src/XrdCeph/XrdCephPosix.cc:822:124: error: no matching function for call to 'max(uint64_t&, __off64_t)'
  822 |       fr->maxOffsetWritten = std::max(fr->maxOffsetWritten, awa->aiop->sfsAio.aio_offset + awa->aiop->sfsAio.aio_nbytes - 1);
      |                                                                                                                            ^
In file included from /usr/include/c++/10/memory:63,
                 from .../xrootd-5.3.1/src/XrdCeph/src/XrdCeph/XrdCephPosix.cc:36:
/usr/include/c++/10/bits/stl_algobase.h:254:5: note: candidate: 'template<class _Tp> constexpr const _Tp& std::max(const _Tp&, const _Tp&)'
  254 |     max(const _Tp& __a, const _Tp& __b)
      |     ^~~
/usr/include/c++/10/bits/stl_algobase.h:254:5: note:   template argument deduction/substitution failed:
.../xrootd-5.3.1/src/XrdCeph/src/XrdCeph/XrdCephPosix.cc:822:124: note:   deduced conflicting types for parameter 'const _Tp' ('long long unsigned int' and '__off64_t' {aka 'long long int'})
  822 |       fr->maxOffsetWritten = std::max(fr->maxOffsetWritten, awa->aiop->sfsAio.aio_offset + awa->aiop->sfsAio.aio_nbytes - 1);
      |                                                                                                                            ^
In file included from /usr/include/c++/10/memory:63,
                 from .../xrootd-5.3.1/src/XrdCeph/src/XrdCeph/XrdCephPosix.cc:36:
/usr/include/c++/10/bits/stl_algobase.h:300:5: note: candidate: 'template<class _Tp, class _Compare> constexpr const _Tp& std::max(const _Tp&, const _Tp&, _Compare)'
  300 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |     ^~~
/usr/include/c++/10/bits/stl_algobase.h:300:5: note:   template argument deduction/substitution failed:
.../xrootd-5.3.1/src/XrdCeph/src/XrdCeph/XrdCephPosix.cc:822:124: note:   deduced conflicting types for parameter 'const _Tp' ('long long unsigned int' and '__off64_t' {aka 'long long int'})
  822 |       fr->maxOffsetWritten = std::max(fr->maxOffsetWritten, awa->aiop->sfsAio.aio_offset + awa->aiop->sfsAio.aio_nbytes - 1);
      |                                                                                                                            ^
``'
