### PR TITLE
Update compile flag

### DIFF
--- a/cmake/XRootDOSDefs.cmake
+++ b/cmake/XRootDOSDefs.cmake
@@ -11,7 +11,7 @@ set( LIBRARY_PATH_PREFIX "lib" )
 # GCC
 #-------------------------------------------------------------------------------
 if( CMAKE_COMPILER_IS_GNUCXX )
-  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11" )
+  set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14" )
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror" )
   set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter" )
   # gcc 4.1 is retarded

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -1276,7 +1276,28 @@ int ceph_posix_unlink(XrdOucEnv* env, const char *pathname) {
   if (0 == striper) {
     return -EINVAL;
   }
-  return striper->remove(file.name);
+  int rc = striper->remove(file.name);
+  if (rc != -EBUSY) {
+    return rc; 
+  }
+  // if EBUSY returned, assume the file is locked; so try to remove the lock
+  logwrapper((char*)"ceph_posix_unlink : unlink failed with -EBUSY %s, now trying to remove lock.", pathname);  
+
+  // lock name is only exposed in the libradosstriper source file, so hardcode it here. 
+  rc = ceph_posix_internal_removexattr(file, "lock.striper.lock");
+  if (rc !=0 ) {
+    logwrapper((char*)"ceph_posix_unlink : unlink rmxattr failed %s, %d", pathname, rc);
+    return rc;
+  }
+
+  // now try to remove again
+  rc = striper->remove(file.name);
+  if (rc != 0) {
+    logwrapper((char*)"ceph_posix_unlink : unlink failed after lock removal %s, %d", pathname, rc);
+  } else {
+    logwrapper((char*)"ceph_posix_unlink : unlink suceeded after lock removal %s, %d", pathname, rc);
+  }
+  return rc; 
 }
 
 DIR* ceph_posix_opendir(XrdOucEnv* env, const char *pathname) {

--- a/src/XrdCeph/XrdCephPosix.cc
+++ b/src/XrdCeph/XrdCephPosix.cc
@@ -947,7 +947,7 @@ static void ceph_aio_read_complete(rados_completion_t c, void *arg) {
     XrdSysMutexHelper lock(fr->statsMutex);
     fr->asyncRdCompletionCount++;
   }
-  awa->callback(awa->aiop, rc == 0 ? awa->nbBytes : rc);
+  awa->callback(awa->aiop, rc );
   delete(awa);
 }
 


### PR DESCRIPTION
Hi Ian, 

This change edits line 14 of xrootd-ceph/cmake/XRootDOSDefs.cmake by replacing -std=c++11 with -std=c++14 
so that we can compile xroot-ceph plugin with the same flag used for the main 
XRootD code. 

George